### PR TITLE
test(s2s): add additional test for no S2S token returned or generated

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
     //         statements: 80,
     //     },
     // },
-    resetMocks: true,
+    restoreMocks: true,
     globals: {
         'ts-jest': {
             compiler: 'ttypescript',

--- a/src/auth/s2s/s2s.class.spec.ts
+++ b/src/auth/s2s/s2s.class.spec.ts
@@ -135,4 +135,23 @@ describe('S2SAuth', () => {
         expect(next).toHaveBeenCalledWith(Error('Failed to request S2S token'))
         expect(result).toBeUndefined()
     })
+
+    it('should do nothing if no S2S token is returned or generated', async () => {
+        const req = {
+            headers: {},
+        } as Request
+        const res = {} as Response
+        const next = jest.fn()
+
+        // Mock the http.post call to return no token data
+        jest.spyOn(http, 'post').mockImplementation(
+            () => (Promise.resolve({ data: null }) as unknown) as AxiosPromise<string>,
+        )
+
+        const result = await s2sAuth.s2sHandler(req, res, next)
+        // There should not be any S2S token in the request headers
+        expect(req.headers).toEqual({})
+        expect(next).not.toHaveBeenCalled()
+        expect(result).toBeUndefined()
+    })
 })

--- a/src/auth/s2s/s2s.class.ts
+++ b/src/auth/s2s/s2s.class.ts
@@ -103,7 +103,7 @@ export class S2SAuth extends events.EventEmitter {
     private postS2SLease = async (): Promise<string> => {
         const oneTimePassword = authenticator.generate(this.s2sConfig.s2sSecret)
 
-        this.logger.info('Requesting S2S token for microservice: ', this.s2sConfig.microservice)
+        this.logger.info('Requesting S2S token for microservice:', this.s2sConfig.microservice)
 
         const request = await http.post(`${this.s2sConfig.s2sEndpointUrl}`, {
             microservice: this.s2sConfig.microservice,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9772,9 +9772,9 @@ widest-line@^2.0.0:
     string-width "^2.1.1"
 
 windows-release@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.3.0.tgz#dce167e9f8be733f21c849ebd4d03fe66b29b9f0"
-  integrity sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.3.1.tgz#cb4e80385f8550f709727287bf71035e209c4ace"
+  integrity sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==
   dependencies:
     execa "^1.0.0"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-1928

### Change description ###
Additional test to cover an execution path previously omitted; coverage now at 100%. Also sets restoreMocks to true in the Jest configuration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
