### PR TITLE
test(oidc): remove redundant afterEach code block

### DIFF
--- a/src/auth/oidc/models/openid.class.spec.ts
+++ b/src/auth/oidc/models/openid.class.spec.ts
@@ -4,10 +4,6 @@ import { Request, Response, NextFunction } from 'express'
 import { AUTH } from '../../auth.constants'
 import { Issuer, Strategy, Client } from 'openid-client'
 
-afterEach(() => {
-    jest.restoreAllMocks()
-})
-
 test('OIDC Auth', () => {
     expect(oidc).toBeDefined()
 })


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-1928

### Change description ###
Restoring Jest mocks is now configured to be true by default in the Jest configuration, so it is no
longer required to do it here.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
