### PR TITLE
test(filesessionstore): unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test": "jest --env node",
+    "test:coverage": "jest --env node --coverage",
     "build": "tsc",
     "lint": "eslint \"*/**/*.{js,ts}\" --quiet --fix",
     "commit": "git cz",

--- a/src/session/models/fileSessionStore.class.spec.ts
+++ b/src/session/models/fileSessionStore.class.spec.ts
@@ -1,0 +1,11 @@
+import { createMock } from 'ts-auto-mock'
+
+import fileSessionStore from './fileSessionStore.class'
+import { FileSessionMetadata } from './sessionMetadata.interface'
+
+describe('getStore()', () => {
+    it('should return', () => {
+        const fileSessionMetadata = createMock<FileSessionMetadata>()
+        expect(fileSessionStore.getStore(fileSessionMetadata)).toBeDefined()
+    })
+})


### PR DESCRIPTION
1. Telling Jest running that we're running on Node, which fixes an issue with this unit test.
2. Adding a unit test around file session storage.