### PR TITLE
fix(csrf): value not read from cookie

### DIFF
--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -308,8 +308,29 @@ export abstract class Strategy extends events.EventEmitter {
     public initialiseCSRF = (): void => {
         if (this.options.useCSRF) {
             this.logger.log('initialising CSRF middleware')
-            this.router.use(csrf())
+            this.router.use(
+                csrf({
+                    value: this.getCSRFValue,
+                }),
+            )
         }
+    }
+
+    /**
+     * retrieve the csrf token value, lastly from sent cookies
+     * @param req
+     * @return string
+     */
+    public getCSRFValue = (req: Request): string => {
+        return (
+            (req.body && req.body._csrf) ||
+            (req.query && req.query._csrf) ||
+            req.headers['csrf-token'] ||
+            req.headers['xsrf-token'] ||
+            req.headers['x-csrf-token'] ||
+            req.headers['x-xsrf-token'] ||
+            req.cookies['XSRF-TOKEN']
+        )
     }
 
     public addHeaders = (): void => {


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
By default, csrf middleware reads from body/query/headers. This is fine for an SPA like angular as we set the cookie which gets picked up. However, standalone routes like media-viewer do not send this information across, hence we read the value directly from cookies sent in request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
