### PR TITLE
fix(strategy.class.ts): password is URL encoded now

### DIFF
--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -294,7 +294,9 @@ export abstract class Strategy extends events.EventEmitter {
             const axiosConfig = {
                 headers: { 'content-type': 'application/x-www-form-urlencoded' },
             }
-            const response = await http.post(url, null, axiosConfig)
+
+            const body = this.getRequestBody(this.options)
+            const response = await http.post(url, body, axiosConfig)
             return response.data
         } catch (error) {
             this.logger.error('error generating authentication token => ', error)
@@ -433,14 +435,21 @@ export abstract class Strategy extends events.EventEmitter {
         }
     }
 
-    public getUrlFromOptions = (options: AuthOptions): string => {
+    public getRequestBody = (options: AuthOptions): string => {
         if (options.routeCredential) {
             const userName = options.routeCredential.userName
             const userPassword = encodeURIComponent(options.routeCredential.password)
             const scope = options.routeCredential?.scope
             const clientSecret = options.clientSecret
             const idamClient = options.clientID
-            return `${options.logoutURL}/o/token?grant_type=password&password=${userPassword}&username=${userName}&scope=${scope}&client_id=${idamClient}&client_secret=${clientSecret}`
+            return `grant_type=password&password=${userPassword}&username=${userName}&scope=${scope}&client_id=${idamClient}&client_secret=${clientSecret}`
+        }
+        throw new Error('options.routeCredential missing values')
+    }
+
+    public getUrlFromOptions = (options: AuthOptions): string => {
+        if (options.routeCredential) {
+            return `${options.logoutURL}/o/token`
         }
         throw new Error('missing routeCredential in options')
     }

--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -291,7 +291,10 @@ export abstract class Strategy extends events.EventEmitter {
     public generateToken = async (): Promise<any | undefined> => {
         const url = this.getUrlFromOptions(this.options)
         try {
-            const response = await http.post(url)
+            const axiosConfig = {
+                headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            }
+            const response = await http.post(url, null, axiosConfig)
             return response.data
         } catch (error) {
             this.logger.error('error generating authentication token => ', error)
@@ -431,11 +434,14 @@ export abstract class Strategy extends events.EventEmitter {
     }
 
     public getUrlFromOptions = (options: AuthOptions): string => {
-        const userName = options.routeCredential?.userName
-        const userPassword = options.routeCredential?.password
-        const scope = options.routeCredential?.scope
-        const clientSecret = options.clientSecret
-        const idamClient = options.clientID
-        return `${options.logoutURL}/o/token?grant_type=password&password=${userPassword}&username=${userName}&scope=${scope}&client_id=${idamClient}&client_secret=${clientSecret}`
+        if (options.routeCredential) {
+            const userName = options.routeCredential.userName
+            const userPassword = encodeURIComponent(options.routeCredential.password)
+            const scope = options.routeCredential?.scope
+            const clientSecret = options.clientSecret
+            const idamClient = options.clientID
+            return `${options.logoutURL}/o/token?grant_type=password&password=${userPassword}&username=${userName}&scope=${scope}&client_id=${idamClient}&client_secret=${clientSecret}`
+        }
+        throw new Error('missing routeCredential in options')
     }
 }

--- a/src/auth/oidc/models/openid.class.spec.ts
+++ b/src/auth/oidc/models/openid.class.spec.ts
@@ -646,7 +646,10 @@ test('generateToken', async () => {
     const spyHttp = jest.spyOn(http, 'post').mockImplementation(async () => await Promise.resolve({} as any))
     oidc.generateToken()
     expect(spyOnGetUrlFromOptions).toBeCalled()
-    expect(spyHttp).toBeCalledWith('someUrl')
+    const axiosConfig = {
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    }
+    expect(spyHttp).toBeCalledWith('someUrl', null, axiosConfig)
 })
 
 test('setHeaders should use currently signed in user when no routeCredentialToken', () => {

--- a/src/auth/oidc/models/openid.class.spec.ts
+++ b/src/auth/oidc/models/openid.class.spec.ts
@@ -669,6 +669,22 @@ test('getRequestBody', () => {
     )
 })
 
+test('getUrlFromOptions without routeCredential', () => {
+    const mockRouter = createMock<Router>()
+    const logger = createMock<typeof console>()
+    const openId = new OpenID(mockRouter, logger)
+
+    expect(() => openId.getUrlFromOptions({} as AuthOptions)).toThrowError('missing routeCredential in options')
+})
+
+test('getRequestBody without routeCredential', () => {
+    const mockRouter = createMock<Router>()
+    const logger = createMock<typeof console>()
+    const openId = new OpenID(mockRouter, logger)
+
+    expect(() => openId.getRequestBody({} as AuthOptions)).toThrowError('options.routeCredential missing values')
+})
+
 test('generateToken', async () => {
     const spyOnGetUrlFromOptions = jest.spyOn(oidc, 'getUrlFromOptions')
     const spyOnGetRequestBody = jest.spyOn(oidc, 'getRequestBody')


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-4038

### Change description ###

password is not URL encoded

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
