### PR TITLE
fix: redirect logout implementation changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-node-lib",
-  "version": "2.25.9",
+  "version": "2.25.10",
   "description": "Common Nodejs library components for XUI",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-node-lib",
-  "version": "2.25.10",
+  "version": "2.25.9",
   "description": "Common Nodejs library components for XUI",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -117,7 +117,7 @@ export abstract class Strategy extends events.EventEmitter {
         } as any)(req, res, next)
     }
 
-    public setCallbackURL = (req: Request, res: Response, next: NextFunction): void => {
+    public setCallbackURL = (req: Request, _res: Response, next: NextFunction): void => {
         /* istanbul ignore else */
         if (req.session && !req.session.callbackURL) {
             req.app.set('trust proxy', true)
@@ -184,7 +184,7 @@ export abstract class Strategy extends events.EventEmitter {
         })
     }
 
-    public keepAliveHandler = (req: Request, res: Response, next: NextFunction): void => {
+    public keepAliveHandler = (_req: Request, _res: Response, next: NextFunction): void => {
         next()
     }
 
@@ -259,7 +259,7 @@ export abstract class Strategy extends events.EventEmitter {
         return this.jwTokenExpired(jwtData)
     }
 
-    public authenticate = (req: Request, res: Response, next: NextFunction): void => {
+    public authenticate = (req: Request, _res: Response, next: NextFunction): void => {
         if (req.isUnauthenticated()) {
             this.logger.log('unauthenticated')
         }
@@ -268,7 +268,7 @@ export abstract class Strategy extends events.EventEmitter {
 
     public makeAuthorization = (passport: any) => `Bearer ${passport.user.tokenset.accessToken}`
 
-    public setHeaders = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    public setHeaders = async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
         if (req.session?.passport?.user) {
             if (this.isRouteCredentialNeeded(req.path, this.options)) {
                 await this.setCredentialToken(req)

--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -163,7 +163,7 @@ export abstract class Strategy extends events.EventEmitter {
             res.redirect(redirect as string)
         } catch (e) {
             this.logger.error('error => ', e)
-            res.redirect(401, AUTH.ROUTE.DEFAULT_REDIRECT)
+            res.status(401).redirect(AUTH.ROUTE.DEFAULT_REDIRECT)
         }
         this.logger.log('logout end')
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-5343

### Change description ###

Changed redirect logic to ensure it always works, regardless of whether it has been called as part of a promise chain.

See (http://expressjs.com/en/5x/api.html#res.redirect)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
