### PR TITLE
#exui-112: rediect to link expired login link page of state or nonce is stale

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-node-lib",
-  "version": "2.29.6",
+  "version": "2.29.6-exui-112-rc1",
   "description": "Common nodejs library components for XUI",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/src/auth/auth.constants.ts
+++ b/src/auth/auth.constants.ts
@@ -12,5 +12,6 @@ export const AUTH = {
         KEEPALIVE_ROUTE: '/auth/keepalive',
         OAUTH_CALLBACK: '/oauth2/callback',
         LOGOUT: '/auth/logout',
+        EXPIRED_LOGIN_LINK: '/expired-login-link',
     },
 }

--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -280,6 +280,12 @@ export abstract class Strategy extends events.EventEmitter {
             this.emit(AUTH.EVENT.AUTHENTICATE_FAILURE, req, res, next)
         }
 
+        const redirectWithFailure = (errorMessages: string[], INVALID_STATE_ERROR: string, uri: string) => {
+            errorMessages.push(INVALID_STATE_ERROR)
+            emitAuthenticationFailure(errorMessages)
+            return res.redirect(uri)
+        }
+
         passport.authenticate(
             this.strategyName,
             {
@@ -303,19 +309,21 @@ export abstract class Strategy extends events.EventEmitter {
                 }
 
                 if (info) {
-                    if (info.message === INVALID_STATE_ERROR) {
-                        errorMessages.push(INVALID_STATE_ERROR)
-                    }
                     this.logger.info('Authenticate callback info', info)
                 }
 
                 if (!user) {
-                    const message = 'No user details returned by the authentication service, redirecting to login'
-                    errorMessages.push(message)
-                    this.logger.log(message)
-
-                    emitAuthenticationFailure(errorMessages)
-                    return res.redirect(AUTH.ROUTE.LOGIN)
+                    const MISMATCH_NONCE = 'nonce mismatch'
+                    const MISMATCH_STATE = 'state mismatch'
+                    if (info?.message === INVALID_STATE_ERROR) {
+                        return redirectWithFailure(errorMessages, INVALID_STATE_ERROR, AUTH.ROUTE.EXPIRED_LOGIN_LINK)
+                    } else if (info?.message.includes(MISMATCH_NONCE) || info?.message.includes(MISMATCH_STATE)) {
+                        return redirectWithFailure(errorMessages, info.message, AUTH.ROUTE.EXPIRED_LOGIN_LINK)
+                    } else {
+                        const message = 'No user details returned by the authentication service, redirecting to login'
+                        this.logger.log(message)
+                        return redirectWithFailure(errorMessages, message, AUTH.ROUTE.LOGIN)
+                    }
                 }
                 emitAuthenticationFailure(errorMessages)
                 this.verifyLogin(req, user, next, res)


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EXUI-112

### Change description
When a user visits the manage-case url for the first time they are immediately redirected to IDAM to login. If at that point the user bookmarks the IDAM url ("hmcts-access.service.gov.uk" in prod) then that bookmark will incude the State and Nonce values that XUI generated. Whenever a user revisits that bookmark they will experience the following flow:

Users visits bookmarked URL and see login page
User successfully logs in using IDAM
IDAM redirects back to XUI manage-case callback
XUI doesn't recognise the State and redirects back to IDAM with new State (and Nonce)
IDAM displays log in page
User successfully logs in using IDAM
IDAM redirects back to XUI manage-case callback
XUI displays cases
This ticket extends: [EUI-4584](https://tools.hmcts.net/jira/browse/EUI-4584) 

To understand the business impact, as part of the aforementioned ticket, we added logging into application insights, which can be seen [here|[https://portal.azure.com/?whr=live.com#@HMCTS.NET/resource/subscriptions/8999dec3-0104-4a27-[…].Insights/components/xui-webapp-appinsights-prod/logs](https://portal.azure.com/?whr=live.com#@HMCTS.NET/resource/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/xui-webapp-prod/providers/Microsoft.Insights/components/xui-webapp-appinsights-prod/logs)]

### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

