### PR TITLE
EXUI-3994 - update to npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-node-lib",
-  "version": "2.30.10-exui-3994",
+  "version": "2.30.10",
   "description": "Common nodejs library components for XUI",
   "main": "dist/index",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### Jira link

See [EXUI-3994](https://tools.hmcts.net/jira/browse/EXUI-3994)

### Change description

Refactored our github actions workflow to use trusted publishing flow instead of the deprecated classic tokens

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No
