### PR TITLE
chore: Update logout to pass id_token as well as post_logout_redirect_uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-node-lib",
-  "version": "2.30.14",
+  "version": "2.30.14-4583",
   "description": "Common nodejs library components for XUI",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/src/auth/models/strategy.class.spec.ts
+++ b/src/auth/models/strategy.class.spec.ts
@@ -59,3 +59,29 @@ test('redactingLogReplacer should redact nested sensitive keys and retain non-se
     expect(serialized).toContain('"serviceAuthorization":"[REDACTED]"')
     expect(serialized).toContain('"tokenURL":"[REDACTED]"')
 })
+
+test('getSSOLogoutUrl should include required end session parameters using the id token', async () => {
+    const logger = getMockLogger()
+    const strategy = new TestStrategy(logger)
+    await strategy.initialiseStrategy({
+        ssoLogoutURL: 'http://idam.test/o/endSession',
+    })
+
+    const ssoLogoutUrl = strategy.getSSOLogoutUrl('http://service.test', 'id-token-value') as string
+    const parsedUrl = new URL(ssoLogoutUrl)
+
+    expect(`${parsedUrl.origin}${parsedUrl.pathname}`).toEqual('http://idam.test/o/endSession')
+    expect(parsedUrl.searchParams.get('post_logout_redirect_uri')).toEqual('http://service.test')
+    expect(parsedUrl.searchParams.get('id_token_hint')).toEqual('id-token-value')
+    expect(parsedUrl.searchParams.get('id_token_hint')).not.toEqual('access-token-value')
+})
+
+test('getSSOLogoutUrl should not build an end session URL without an id token', async () => {
+    const logger = getMockLogger()
+    const strategy = new TestStrategy(logger)
+    await strategy.initialiseStrategy({
+        ssoLogoutURL: 'http://idam.test/o/endSession',
+    })
+
+    expect(strategy.getSSOLogoutUrl('http://service.test')).toBeUndefined()
+})

--- a/src/auth/models/strategy.class.ts
+++ b/src/auth/models/strategy.class.ts
@@ -219,7 +219,7 @@ export abstract class Strategy extends events.EventEmitter {
 
         try {
             this.logger.log('logout start')
-            const { accessToken, refreshToken } = reqSession?.passport.user.tokenset || null
+            const { accessToken, refreshToken, idToken } = reqSession?.passport.user.tokenset || null
 
             const auth = this.getAuthorization(this.options.clientID, this.options.clientSecret)
 
@@ -250,9 +250,7 @@ export abstract class Strategy extends events.EventEmitter {
                     protocol: req.protocol,
                     host: req.get('host'),
                 })
-                const params = new URLSearchParams({ post_logout_redirect_uri: redirectUrl })
-
-                const finalSSOLogoutUrl = `${this.options.ssoLogoutURL}?${params.toString()}`
+                const finalSSOLogoutUrl = this.getSSOLogoutUrl(redirectUrl, idToken)
 
                 const redirect = finalSSOLogoutUrl ? finalSSOLogoutUrl : AUTH.ROUTE.LOGIN
 
@@ -268,6 +266,19 @@ export abstract class Strategy extends events.EventEmitter {
             res.status(401).redirect(AUTH.ROUTE.DEFAULT_REDIRECT)
         }
         this.logger.log('logout end')
+    }
+
+    public getSSOLogoutUrl = (redirectUrl: string, idToken?: string): string | undefined => {
+        if (!this.options.ssoLogoutURL || !idToken) {
+            return undefined
+        }
+
+        const params = new URLSearchParams({
+            id_token_hint: idToken,
+            post_logout_redirect_uri: redirectUrl,
+        })
+
+        return `${this.options.ssoLogoutURL}?${params.toString()}`
     }
 
     /* istanbul ignore next */


### PR DESCRIPTION
### Jira link

See [EXUI-4583](https://tools.hmcts.net/jira/browse/EXUI-4583)

### Change description

Update logout code to pass both id_token and post_logout_redirect_uri when a user logs out, previously we ere only sending post_logout_redirect_uri.

### Testing done

Ran code locally and observed network request on logout, this now contains id_token
